### PR TITLE
터미널 탭에 vim대신 파일이름 보이게 하기

### DIFF
--- a/.vimrc
+++ b/.vimrc
@@ -3,6 +3,8 @@ syntax on
 
 filetype indent on
 filetype plugin on
+let &titlestring=@%
+set title
 set encoding=UTF-8
 set fileencodings=UTF-8
 set tabstop=2


### PR DESCRIPTION
파일 구별이 안되서 추가해봄
